### PR TITLE
feature/TS-104 Return only pending 'Annual Leave' holidays from /dashboard/getEmployeeEvents api call 

### DIFF
--- a/src/main/java/com/unosquare/admin_core/back_end/controller/DashboardController.java
+++ b/src/main/java/com/unosquare/admin_core/back_end/controller/DashboardController.java
@@ -44,6 +44,16 @@ public class DashboardController {
             return model;
     }
 
+    @GetMapping(value = "/getPendingEmployeeEvents", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public EmployeeEventViewModel getDashboardPendingEventsByEmployeeId(@RequestParam(value = "date")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)  LocalDate date) {
+        List<EventDTO> events = dashboardService.getPendingEmployeeDashboardEvents(employeeCredentialsViewModel.getUserId(), date);
+        List<DashboardEventViewModel> results = events.stream().map(event -> modelMapper.map(event, DashboardEventViewModel.class)).collect(Collectors.toList());
+        EmployeeEventViewModel model = new EmployeeEventViewModel();
+        model.setEvents(results);
+        return model;
+    }
+
     @GetMapping(value = "/getTeamEvents", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     public EmployeeEventViewModel getTeamEventsByEmployeeId(@RequestParam(value = "date")  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)  LocalDate date) {

--- a/src/main/java/com/unosquare/admin_core/back_end/controller/HolidayController.java
+++ b/src/main/java/com/unosquare/admin_core/back_end/controller/HolidayController.java
@@ -17,6 +17,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -53,6 +54,17 @@ public class HolidayController extends BaseController {
     public List<HolidayViewModel> findHolidaysByEmployeeId(@PathVariable("employeeId") int employeeId) {
         List<EventDTO> holidays = eventService.findByEmployee(employeeId);
         return mapEventDtosToHolidays(holidays);
+    }
+
+    @GetMapping(value = "findEventsByEmployeeId/{employeeId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public List<List<HolidayViewModel>> findEventsByEmployeeId(@PathVariable("employeeId") int employeeId) {
+        List<List<HolidayViewModel>> events = new ArrayList<>();
+        List<EventDTO> annualLeave = eventService.findALByEmployee(employeeId);
+        List<EventDTO> workFromHome = eventService.findWFHByEmployee(employeeId);
+        events.add(mapEventDtosToHolidays(annualLeave));
+        events.add(mapEventDtosToHolidays(workFromHome));
+        return events;
     }
 
     @PostMapping(value = "/", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/unosquare/admin_core/back_end/repository/DashboardRepository.java
+++ b/src/main/java/com/unosquare/admin_core/back_end/repository/DashboardRepository.java
@@ -24,6 +24,20 @@ public interface DashboardRepository extends JpaRepository<Event, Integer> {
                                                    @Param("endDate") LocalDate endDate);
 
     @Query(value = "SELECT e FROM Event e " +
+            "WHERE " +
+            "((e.startDate BETWEEN :startDate AND :endDate) OR " +
+            "(e.endDate BETWEEN :startDate AND :endDate) OR " +
+            "(e.startDate > :startDate AND e.endDate < :endDate)) " +
+            "AND " +
+            "(e.eventStatus = '1') AND (e.eventType = '1') OR (e.eventType = '2') " +
+            "AND " +
+            "e.employee.employeeId = :employeeId"
+    )
+    List<Event> findCalendarMonthPendingEventsForEmployee(@Param("employeeId") int employeeId,
+                                                          @Param("startDate") LocalDate startDate,
+                                                          @Param("endDate") LocalDate endDate);
+
+    @Query(value = "SELECT e FROM Event e " +
             "INNER JOIN Contract c on e.employee.employeeId = c.employee.employeeId " +
             "WHERE " +
             "((e.startDate BETWEEN :startDate AND :endDate) OR " +

--- a/src/main/java/com/unosquare/admin_core/back_end/repository/EventRepository.java
+++ b/src/main/java/com/unosquare/admin_core/back_end/repository/EventRepository.java
@@ -5,6 +5,8 @@ import com.unosquare.admin_core.back_end.entity.Event;
 import com.unosquare.admin_core.back_end.entity.EventStatus;
 import com.unosquare.admin_core.back_end.entity.EventType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -12,6 +14,22 @@ import java.util.List;
 public interface EventRepository extends JpaRepository<Event, Integer> {
 
     List<Event> findByEmployee(Employee employee);
+
+    @Query(value = "SELECT e FROM Event e " +
+            "WHERE " +
+            "(e.eventStatus = '1') AND (e.eventType = '1') " +
+            "AND " +
+            "e.employee.employeeId = :employeeId"
+    )
+    List<Event> findALByEmployee(@Param("employeeId") int employeeId);
+
+    @Query(value = "SELECT e FROM Event e " +
+            "WHERE " +
+            "(e.eventStatus = '1') AND (e.eventType = '2') " +
+            "AND " +
+            "e.employee.employeeId = :employeeId"
+    )
+    List<Event> findWFHByEmployee(@Param("employeeId") int employeeId);
 
     Event findByEmployeeAndStartDateAndEndDateAndEventType(Employee employee, LocalDate startDate, LocalDate endDate, EventType eventType);
 

--- a/src/main/java/com/unosquare/admin_core/back_end/service/DashboardService.java
+++ b/src/main/java/com/unosquare/admin_core/back_end/service/DashboardService.java
@@ -46,6 +46,20 @@ public class DashboardService {
         return eventDTOS;
     }
 
+    public List<EventDTO> getPendingEmployeeDashboardEvents(int employeeId, LocalDate date) {
+        LocalDate startDate = getMonthStartDate(date);
+        LocalDate endDate = getMonthEndDate(date);
+        List<Event> result = dashboardRepository.findCalendarMonthPendingEventsForEmployee(employeeId, startDate, endDate);
+        List<EventDTO> eventDTOS = result.stream().map(event -> modelMapper.map(event, EventDTO.class)).collect(Collectors.toList());
+        for (EventDTO event : eventDTOS){
+            EventMessage message = eventMessageRepository.findLatestEventMessagesByEventId(event.getEventId());
+            if (message != null) {
+                event.setLatestMessage(modelMapper.map(message, EventMessageDTO.class));
+            }
+        }
+        return eventDTOS;
+    }
+
     public List<EventDTO> getTeamDashboardEvents(int employeeId, LocalDate date){
         LocalDate startDate = getMonthStartDate(date);
         LocalDate endDate = getMonthEndDate(date);

--- a/src/main/java/com/unosquare/admin_core/back_end/service/EventService.java
+++ b/src/main/java/com/unosquare/admin_core/back_end/service/EventService.java
@@ -184,5 +184,15 @@ public class EventService {
         }
         return null;
     }
+
+    public List<EventDTO> findALByEmployee(int employeeId) {
+        List<Event> events = eventRepository.findALByEmployee(employeeId);
+        return mapEventsToDtos(events);
+    }
+
+    public List<EventDTO> findWFHByEmployee(int employeeId) {
+        List<Event> events = eventRepository.findWFHByEmployee(employeeId);
+        return mapEventsToDtos(events);
+    }
 }
 


### PR DESCRIPTION
Returning an array of arrays splitting Annual Leave and WFH on a new end point so front end can disregard wfh events at the moment.

(Also branch name dosen't follow new standards, won't happen again)