### PR TITLE
Fixed bug with open-ended contracts.

### DIFF
--- a/AdminCore.DTOs/ContractDto.cs
+++ b/AdminCore.DTOs/ContractDto.cs
@@ -17,6 +17,6 @@ namespace AdminCore.DTOs
 
     public DateTime StartDate { get; set; }
 
-    public DateTime EndDate { get; set; }
+    public DateTime? EndDate { get; set; }
   }
 }

--- a/AdminCore.WebApp/Models/Contract/CreateContractViewModel.cs
+++ b/AdminCore.WebApp/Models/Contract/CreateContractViewModel.cs
@@ -10,6 +10,6 @@ namespace AdminCore.WebApi.Models.Contract
 
     public DateTime StartDate { get; set; }
 
-    public DateTime EndDate { get; set; }
+    public DateTime? EndDate { get; set; }
   }
 }


### PR DESCRIPTION
Open-ended contracts were not being returned in dashboard query.
DateTime for EndDate was being defaulted to 01-01-0001 in viewModel and dto and query was checking for a null end date.
Made view model and dto end date nullable to match model.