### PR TITLE
Return approved events between start and end dates

### DIFF
--- a/AdminCore.Common/Interfaces/IEventService.cs
+++ b/AdminCore.Common/Interfaces/IEventService.cs
@@ -13,7 +13,7 @@ namespace AdminCore.Common.Interfaces
 
     IList<EventDto> GetEventsByEmployeeId(int employeeId, EventTypes eventType);
 
-    IList<EventDateDto> GetEventDatesByEmployeeAndStartAndEndDates(DateTime startDate, DateTime endDate, int employeeId);
+    IList<EventDateDto> GetApprovedEventDatesByEmployeeAndStartAndEndDates(DateTime startDate, DateTime endDate, int employeeId);
 
     EventDto GetEvent(int id);
 

--- a/AdminCore.Services/EventService.cs
+++ b/AdminCore.Services/EventService.cs
@@ -53,12 +53,13 @@ namespace AdminCore.Services
       return _mapper.Map<IList<EventDto>>(QueryEventsByEmployeeId(eventTypeId, eventIds));
     }
 
-    public IList<EventDateDto> GetEventDatesByEmployeeAndStartAndEndDates(DateTime startDate, DateTime endDate, int employeeId)
+    public IList<EventDateDto> GetApprovedEventDatesByEmployeeAndStartAndEndDates(DateTime startDate, DateTime endDate, int employeeId)
     {
       var eventDates = DatabaseContext.EventDatesRepository.Get(x => (x.StartDate.Date >= startDate.Date
                                                                          && x.EndDate.Date <= endDate.Date
                                                                          || x.EndDate.Date == startDate.Date)
-                                                                         && x.Event.EmployeeId == employeeId,
+                                                                         && x.Event.EmployeeId == employeeId
+                                                                         && x.Event.EventStatusId == (int)EventStatuses.Approved,
                                                               null, x => x.Event);
 
       return _mapper.Map<IList<EventDateDto>>(eventDates);
@@ -274,7 +275,7 @@ namespace AdminCore.Services
     private bool IsEventDatesAlreadyBooked(EventDateDto eventDates, int employeeId)
     {
       var employeeEvents =
-        GetEventDatesByEmployeeAndStartAndEndDates(eventDates.StartDate, eventDates.EndDate, employeeId);
+        GetApprovedEventDatesByEmployeeAndStartAndEndDates(eventDates.StartDate, eventDates.EndDate, employeeId);
       if (employeeEvents.Any())
       {
         throw new Exception("Holiday dates already booked.");


### PR DESCRIPTION
Used to check if the event is valid, now checking if the events within the daterange are approved, otherwise the user can continue to book holidays until one is approved