### PR TITLE
Created an EventController that accepts the EventTypeId

### DIFF
--- a/AdminCore.Services/EventService.cs
+++ b/AdminCore.Services/EventService.cs
@@ -392,11 +392,13 @@ namespace AdminCore.Services
 
     private Event BuildNewEvent(int employeeId, EventTypes eventTypes)
     {
+      var eventStatusId = AutoApproveEventsNotNeedingAdminApproval(eventTypes);
+
       var newEvent = new Event
       {
         DateCreated = DateTime.Now,
         EmployeeId = employeeId,
-        EventStatusId = (int)EventStatuses.AwaitingApproval,
+        EventStatusId = eventStatusId,
         EventTypeId = (int)eventTypes,
         EventDates = new List<EventDate>(),
         LastModified = _dateService.GetCurrentDateTime()
@@ -569,6 +571,17 @@ namespace AdminCore.Services
     private static bool IsNotPublicHoliday(Event eventToUpdate)
     {
       return eventToUpdate.EventTypeId != (int)EventTypes.PublicHoliday;
+    }
+
+    private static int AutoApproveEventsNotNeedingAdminApproval(EventTypes eventTypes)
+    {
+      var eventStatusId = (int)EventStatuses.AwaitingApproval;
+      if (eventTypes == EventTypes.WorkingFromHome)
+      {
+        eventStatusId = (int)EventStatuses.Approved;
+      }
+
+      return eventStatusId;
     }
   }
 }

--- a/AdminCore.WebApp/Controllers/EventController.cs
+++ b/AdminCore.WebApp/Controllers/EventController.cs
@@ -1,0 +1,276 @@
+﻿using AdminCore.Common.Interfaces;
+using AdminCore.Constants.Enums;
+using AdminCore.DTOs.Employee;
+using AdminCore.DTOs.Event;
+using AdminCore.WebApi.Models.Event;
+using AdminCore.WebApi.Models.EventMessage;
+using AutoMapper;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Net;
+
+namespace AdminCore.WebApi.Controllers
+{
+  [ApiController]
+  [Authorize]
+  [Route("[controller]")]
+  public class EventController : BaseController
+  {
+    private readonly IEventService _eventService;
+    private readonly IMapper _mapper;
+    private readonly EmployeeDto _employee;
+    private readonly IEventMessageService _eventMessageService;
+
+    public EventController(IEventService wfhEventService, IEventMessageService eventMessageService, IMapper mapper, IAuthenticatedUser authenticatedUser)
+      : base(mapper)
+    {
+      _eventService = wfhEventService;
+      _eventMessageService = eventMessageService;
+      _mapper = mapper;
+      _employee = authenticatedUser.RetrieveLoggedInUser();
+    }
+
+    [HttpGet()]
+    public IActionResult GetAllHolidays()
+    {
+      var returnedEvents = _eventService.GetEmployeeEvents(EventTypes.AnnualLeave);
+      if (returnedEvents != null)
+      {
+        return Ok(_mapper.Map<IList<EventViewModel>>(returnedEvents));
+      }
+
+      return StatusCode((int)HttpStatusCode.NoContent, "No Event exists");
+    }
+
+    [HttpGet("findEventsByTypeId/{eventTypeId}")]
+    public IActionResult GetAllEventsByEventType(int eventTypeId)
+    {
+      var returnedEvents = _eventService.GetEmployeeEvents((EventTypes)eventTypeId); //TODO
+      if (returnedEvents != null)
+      {
+        return Ok(_mapper.Map<IList<EventViewModel>>(returnedEvents));
+      }
+
+      return StatusCode((int)HttpStatusCode.NoContent, "No Event exists");
+    }
+
+    [HttpGet("{eventId}")]
+    public IActionResult GetEventByEventId(int eventId)
+    {
+      var returnedEvent = _eventService.GetEvent(eventId);
+      if (returnedEvent != null)
+      {
+        return Ok(_mapper.Map<EventViewModel>(returnedEvent));
+      }
+
+      return StatusCode((int)HttpStatusCode.NoContent, $"No event found for event ID: { eventId.ToString() }");
+    }
+
+    [HttpGet("findByEmployeeId/{employeeId}/{eventTypeId}")]
+    public IActionResult GetEventByEmployeeId(int employeeId, int eventTypeId)
+    {
+      var events = _eventService.GetEventsByEmployeeId(employeeId, (EventTypes)eventTypeId);
+      if (events != null)
+      {
+        return Ok(_mapper.Map<IList<EventViewModel>>(events));
+      }
+
+      return StatusCode((int)HttpStatusCode.NoContent, $"No event found for employee ID: { _employee.EmployeeId }");
+    }
+
+    [HttpGet("findEmployeeHolidayStats")]
+    public IActionResult GetEmployeeHolidayStats()
+    {
+      var holidayStats = _eventService.GetHolidayStatsForUser(_employee.EmployeeId);
+      if (holidayStats != null)
+      {
+        return Ok(_mapper.Map<HolidayStatsViewModel>(holidayStats));
+      }
+
+      return StatusCode((int)HttpStatusCode.NoContent, "No Holiday exists");
+    }
+
+    [HttpGet("findByDateBetween/{startDate}/{endDate}/{eventTypeId}")]
+    public IActionResult GetHolidayByDateBetween(string startDate, string endDate, int eventTypeId)
+    {
+      if (IsDatesValid(startDate, endDate))
+      {
+        return Ok(GetEventsBetweenDates(startDate, endDate, eventTypeId));
+      }
+      return BadRequest("Please use a valid date format for start and/or end dates");
+    }
+
+    [HttpGet("findByEventStatus/{eventStatusId}/{eventTypeId}")]
+    public IActionResult GetEventByStatusType(int eventStatusId, int eventTypeId)
+    {
+      var events = _eventService.GetEventByStatus((EventStatuses)eventStatusId, (EventTypes)eventTypeId);
+      if (events != null)
+      {
+        return Ok(_mapper.Map<IList<EventViewModel>>(events));
+      }
+      return StatusCode((int)HttpStatusCode.NoContent, "No Event exists");
+    }
+
+    [HttpGet("findEventMessages/{eventId}")]
+    public IActionResult GetEventMessages(int eventId)
+    {
+      var eventMessages = _eventMessageService.GetAllEventMessagesForEvent(eventId);
+      if (eventMessages != null)
+      {
+        return Ok(_mapper.Map<IList<EventMessageViewModel>>(eventMessages));
+      }
+
+      return StatusCode((int)HttpStatusCode.NoContent, "No Messages exists");
+    }
+
+    [HttpGet("findEmployeeHolidayStats/{employeeId}")]
+    public IActionResult GetEmployeeHolidayStats(int employeeId)
+    {
+      var holidayStats = _eventService.GetHolidayStatsForUser(employeeId);
+      if (holidayStats != null)
+      {
+        return Ok(_mapper.Map<HolidayStatsViewModel>(holidayStats));
+      }
+
+      return StatusCode((int)HttpStatusCode.NoContent, "No Holiday exists");
+    }
+
+    [HttpPost]
+    public IActionResult CreateEvent(CreateEventViewModel createEventViewModel)
+    {
+      if (createEventViewModel.EventTypeId == 0)
+      {
+        return StatusCode((int)HttpStatusCode.InternalServerError, "You may not create new public holidays");
+      }
+      var eventDates = _mapper.Map<EventDateDto>(createEventViewModel);
+      try
+      {
+        if (IsHolidayEvent(createEventViewModel.EventTypeId))
+        {
+          _eventService.IsEventValid(eventDates, createEventViewModel.IsHalfDay, _employee.EmployeeId);
+        }
+        _eventService.CreateEvent(eventDates, (EventTypes)createEventViewModel.EventTypeId, _employee.EmployeeId);
+        return Ok($"Event has been created successfully");
+      }
+      catch (Exception ex)
+      {
+        Logger.LogError(ex.Message);
+        return StatusCode((int)HttpStatusCode.InternalServerError, "Error creating event: " + ex.Message);
+      }
+    }
+
+    [HttpPut]
+    public IActionResult UpdateEvent(UpdateEventViewModel updateEventViewModel)
+    {
+      var eventDatesToUpdate = _mapper.Map<EventDateDto>(updateEventViewModel);
+      try
+      {
+        _eventService.IsEventValid(eventDatesToUpdate, updateEventViewModel.IsHalfDay, _employee.EmployeeId);
+        _eventService.UpdateEvent(eventDatesToUpdate, updateEventViewModel.Message, _employee.EmployeeId);
+        return Ok("Holiday has been successfully updated");
+      }
+      catch (Exception ex)
+      {
+        Logger.LogError(ex.Message);
+        return StatusCode((int)HttpStatusCode.InternalServerError, "Error updating holiday: " + ex.Message);
+      }
+    }
+
+    [Authorize("Admin")]
+    [HttpPut("approveEvent")]
+    public IActionResult ApproveEvent(ApproveEventViewModel approveEventViewModel)
+    {
+      try
+      {
+        var eventToApprove = _eventService.GetEvent(approveEventViewModel.EventId);
+        if (eventToApprove.EmployeeId != _employee.EmployeeId)
+        {
+          _eventService.UpdateEventStatus(approveEventViewModel.EventId, EventStatuses.Approved);
+          return Ok("Successfully Approved");
+        }
+        return StatusCode((int)HttpStatusCode.Forbidden, "You may not approve your own Events");
+      }
+      catch (Exception ex)
+      {
+        Logger.LogError(ex.Message);
+        return StatusCode((int)HttpStatusCode.InternalServerError, "Something went wrong approving event");
+      }
+    }
+
+    [HttpPut("cancelEvent")]
+    public IActionResult CancelEvent(CancelEventViewModel cancelEventViewModel)
+    {
+      try
+      {
+        _eventService.UpdateEventStatus(cancelEventViewModel.EventId, EventStatuses.Cancelled);
+        return Ok("Successfully Cancelled");
+      }
+      catch (Exception ex)
+      {
+        Logger.LogError(ex.Message);
+        return StatusCode((int)HttpStatusCode.InternalServerError, "Something went wrong cancelling event");
+      }
+    }
+
+    [Authorize("Admin")]
+    [HttpPut("rejectEvent")]
+    public IActionResult RejectEvent(RejectEventViewModel rejectEventViewModel)
+    {
+      try
+      {
+        _eventService.RejectEvent(rejectEventViewModel.EventId, rejectEventViewModel.Message, _employee.EmployeeId);
+        return Ok("Successfully Rejected");
+      }
+      catch (Exception ex)
+      {
+        Logger.LogError(ex.Message);
+        return StatusCode((int)HttpStatusCode.InternalServerError, "Something went wrong rejecting event");
+      }
+    }
+
+    [HttpPut("addMessageToEvent")]
+    public IActionResult AddMessageToEvent(CreateEventMessageViewModel eventMessageViewModel)
+    {
+      var returnedEvent = _eventService.GetEvent(eventMessageViewModel.EventId);
+      if (returnedEvent != null)
+      {
+        _eventMessageService.CreateGeneralEventMessage(eventMessageViewModel.EventId, eventMessageViewModel.Message, _employee.EmployeeId);
+        return Ok("Successfully Added Message");
+      }
+
+      return StatusCode((int)HttpStatusCode.NoContent, "No Messages exists");
+    }
+
+    private bool ValidateDate(string date)
+    {
+      try
+      {
+        DateTime dt = DateTime.Parse(date);
+        return true;
+      }
+      catch
+      {
+        return false;
+      }
+    }
+
+    private bool IsDatesValid(string startDate, string endDate)
+    {
+      return ValidateDate(startDate) && ValidateDate(endDate);
+    }
+
+    private IList<EventViewModel> GetEventsBetweenDates(string startDate, string endDate, int eventTypeId)
+    {
+      var holidays = _eventService.GetByDateBetween(Convert.ToDateTime(startDate), Convert.ToDateTime(endDate), (EventTypes)eventTypeId);
+      return _mapper.Map<IList<EventViewModel>>(holidays);
+    }
+
+    private static bool IsHolidayEvent(int eventTypeId)
+    {
+      return eventTypeId != (int)EventTypes.WorkingFromHome;
+    }
+  }
+}

--- a/AdminCore.WebApp/Models/Event/CreateEventViewModel.cs
+++ b/AdminCore.WebApp/Models/Event/CreateEventViewModel.cs
@@ -7,5 +7,6 @@ namespace AdminCore.WebApi.Models.Event
     public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
     public bool IsHalfDay { get; set; }
+    public int EventTypeId { get; set; }
   }
 }


### PR DESCRIPTION
Use this with the type ID rather than using specific controllers.
The old controllers still work so the front end can use these while moving over to using the new /Event/ endpoint, they will need pass back the EventTypeId with all their calls from now on to use this.