### PR TITLE
Added Logic for entitled mexican holidays

### DIFF
--- a/AdminCore.DAL/Database/AdmincoreContext.cs
+++ b/AdminCore.DAL/Database/AdmincoreContext.cs
@@ -52,6 +52,8 @@ namespace AdminCore.DAL.Database
 
     public DbSet<PublicHoliday> PublicHolidays { get; set; }
 
+    public DbSet<MexicanHoliday> MexicanHoliday { get; set; }
+
     public DbSet<Team> Teams { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)

--- a/AdminCore.DAL/Entity Framework/EntityFrameworkContext.cs
+++ b/AdminCore.DAL/Entity Framework/EntityFrameworkContext.cs
@@ -33,6 +33,8 @@ namespace AdminCore.DAL.Entity_Framework
 
     private IRepository<EventType> _eventTypeRepository;
 
+    private IRepository<MexicanHoliday> _mexicanHolidayRepository;
+
     private IRepository<PublicHoliday> _publicHolidayRepository;
 
     private IRepository<Team> _teamRepository;
@@ -78,6 +80,9 @@ namespace AdminCore.DAL.Entity_Framework
 
     public IRepository<EventType> EventTypeRepository =>
       _eventTypeRepository ?? (_eventTypeRepository = new EntityFrameworkRepository<EventType>(this));
+
+    public IRepository<MexicanHoliday> MexicanHolidayRepository =>
+      _mexicanHolidayRepository ?? (_mexicanHolidayRepository = new EntityFrameworkRepository<MexicanHoliday>(this));
 
     public IRepository<PublicHoliday> PublicHolidayRepository =>
       _publicHolidayRepository ?? (_publicHolidayRepository = new EntityFrameworkRepository<PublicHoliday>(this));

--- a/AdminCore.DAL/IDatabaseContext.cs
+++ b/AdminCore.DAL/IDatabaseContext.cs
@@ -28,6 +28,8 @@ namespace AdminCore.DAL
 
     IRepository<EventType> EventTypeRepository { get; }
 
+    IRepository<MexicanHoliday> MexicanHolidayRepository { get; }
+
     IRepository<PublicHoliday> PublicHolidayRepository { get; }
 
     IRepository<Team> TeamRepository { get; }

--- a/AdminCore.DAL/Models/MexicanHoliday.cs
+++ b/AdminCore.DAL/Models/MexicanHoliday.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace AdminCore.DAL.Models
+{
+  [Table("mexican_holiday")]
+  public class MexicanHoliday
+  {
+    [Key]
+    [Column("mexican_holiday_id")]
+    public int MexicanHolidayId { get; set; }
+
+    [Column("years_with_company")]
+    public int YearsWithCompany { get; set; }
+
+    [Column("entitled_holidays")]
+    public int EntitledHolidays { get; set; }
+  }
+}

--- a/AdminCore.DatabaseMigration/AdminCore.DatabaseMigration.csproj
+++ b/AdminCore.DatabaseMigration/AdminCore.DatabaseMigration.csproj
@@ -38,6 +38,9 @@
 	<None Update="db\migrations\V1.8__add_public_holidays.sql">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+	<None Update="db\migrations\V1.9__add_mexican_holidays.sql">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/AdminCore.DatabaseMigration/db/migrations/V1.0__original_schema.sql
+++ b/AdminCore.DatabaseMigration/db/migrations/V1.0__original_schema.sql
@@ -406,3 +406,22 @@ TABLESPACE pg_default;
 
 ALTER SEQUENCE public_holiday_public_holiday_id_seq
     OWNED BY public_holiday.public_holiday_id;
+
+				  ----------------------------------------------------------------------------------------
+
+/*
+                                   MEXICAN HOLIDAY TABLE
+*/
+
+  ----------------------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.mexican_holiday
+(
+    mexican_holiday_id integer,
+    years_with_company integer,
+    entitled_holidays integer,
+    CONSTRAINT mexican_holiday_pkey PRIMARY KEY (mexican_holiday_id)
+)
+WITH (
+OIDS = FALSE
+)
+TABLESPACE pg_default;

--- a/AdminCore.DatabaseMigration/db/migrations/V1.9__add_mexican_holidays.sql
+++ b/AdminCore.DatabaseMigration/db/migrations/V1.9__add_mexican_holidays.sql
@@ -1,0 +1,18 @@
+﻿INSERT INTO public.mexican_holiday (mexican_holiday_id, years_with_company, entitled_holidays)
+VALUES (0, 0, 6),
+			 (1, 1, 8),
+       (2, 2, 10),
+       (3, 3, 12),
+			 (4, 4, 14),
+       (5, 5, 16),
+       (6, 6, 16),
+       (7, 7, 16),
+       (8, 8, 16),
+       (9, 9, 16),
+       (10, 10, 18),
+       (11, 11, 18),
+       (12, 12, 18),
+			 (13, 13, 18),
+       (14, 14, 18)
+ON CONFLICT (mexican_holiday_id)
+  DO NOTHING;

--- a/AdminCore.Services/EmployeeService.cs
+++ b/AdminCore.Services/EmployeeService.cs
@@ -139,11 +139,30 @@ namespace AdminCore.Services
       return holidays;
     }
 
-    private static short GetMexicanHolidays(DateTime startDate)
+    private short GetMexicanHolidays(DateTime startDate)
     {
-      short mexicanYearOfIndependence = 1810;
+      if (IsInFirstThreeMonths(startDate, DateTime.Now))
+      {
+        return 0;
+      }
+      return (short)GetHolidaysByYearsWithCompany(startDate); //TODO Add Mexican Public Holidays
+    }
 
-      return mexicanYearOfIndependence;
+    private int GetHolidaysByYearsWithCompany(DateTime startDate)
+    {
+      return DatabaseContext.MexicanHolidayRepository.GetSingle(x => x.YearsWithCompany == GetYearsWithCompany(startDate)).EntitledHolidays;
+    }
+
+    private static int GetYearsWithCompany(DateTime startDate)
+    {
+      var totalDays = (DateTime.Today - startDate).Days;
+      var years = totalDays / 365.25m;
+      return (int)Math.Floor(years);
+    }
+
+    private static bool IsInFirstThreeMonths(DateTime startDate, DateTime currentDate)
+    {
+      return startDate.Year == currentDate.Year && ((currentDate.DayOfYear - startDate.DayOfYear) < 91);
     }
 
     private static short GetNorthernIrishHolidays(DateTime startDate)


### PR DESCRIPTION
Added DB table for holidays
No vacation days until 3 months in:
- After 3 Months and before our 1st anniversary (Between day 91 and day 364) We have  6 vacation days
- 1st Anniversary: 8 vacation days
- 2nd Anniversary: 10 vacation days
- 3rd Anniversary: 12 vacation days
- 4th Anniversary : 14 vacation days
- 5th Anniversary – 9th Anniversary:16 vacation days
- 10th anniversary – 14th anniversary: 18 vacation days