### PR TITLE
Adjust port mapping for admincore-api in docker-compose yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       DB_CONNECTION_STRING: "User ID=user;Password=password;Server=admincore-postgres;Port=5432;Database=AdminCore;Integrated Security=true;Pooling=true;"
     restart: always
     ports:
-      - 80:8081
+      - 8081:8081
     depends_on:
       - admincore-postgres
       - admincore-migration


### PR DESCRIPTION
Exposes backend on port `8080` to meet frontend expectations