### PR TITLE
Revert "Adjust port mapping for admincore-api in docker-compose yaml"

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       DB_CONNECTION_STRING: "User ID=user;Password=password;Server=admincore-postgres;Port=5432;Database=AdminCore;Integrated Security=true;Pooling=true;"
     restart: always
     ports:
-      - 8081:8081
+      - 80:8081
     depends_on:
       - admincore-postgres
       - admincore-migration


### PR DESCRIPTION
Reverts UnosquareBelfast/admin-backend#71

as per @trojanspike `Best to change the env variable in the webpack config - this change will mean having to change the AWS ElasticLoad balancer`