### PR TITLE
BUG: Change reference for Castle.Core in AdminCore.DataETL csproj file.

### DIFF
--- a/AdminCore.DataETL/AdminCore.DataETL.csproj
+++ b/AdminCore.DataETL/AdminCore.DataETL.csproj
@@ -12,12 +12,7 @@
     <ItemGroup>
       <PackageReference Include="AutoMapper" Version="7.0.1" />
       <PackageReference Include="ChoETL" Version="1.1.0.2" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc">
-        <HintPath>C:\Users\richard.gillen\.nuget\packages\castle.core\4.3.1\lib\netstandard1.5\Castle.Core.dll</HintPath>
-      </Reference>
+      <PackageReference Include="Castle.Core" Version="4.4.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Bug meant that nobody who pulled down develop could successfully compile the code due to a bad reference to castle.core.