### PR TITLE
LM-54: implement changes to dashboard controller service dto viewmodel

### DIFF
--- a/AdminCore.DTOs/Dashboard/ClientSnapshotDto.cs
+++ b/AdminCore.DTOs/Dashboard/ClientSnapshotDto.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using System.Collections.Generic;
 
 namespace AdminCore.DTOs.Dashboard
 {
@@ -10,6 +8,6 @@ namespace AdminCore.DTOs.Dashboard
 
     public string ClientName { get; set; }
 
-    public ICollection<TeamSnapshotDto> Teams { get; set; }
+    public ICollection<ProjectSnapshotDto> Projects { get; set; }
   }
 }

--- a/AdminCore.DTOs/Dashboard/ProjectSnapshotDto.cs
+++ b/AdminCore.DTOs/Dashboard/ProjectSnapshotDto.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace AdminCore.DTOs.Dashboard
+{
+  public class ProjectSnapshotDto
+  {
+    public int ProjectId { get; set; }
+
+    public string ProjectName { get; set; }
+
+    public ICollection<TeamSnapshotDto> Teams { get; set; }
+  }
+}

--- a/AdminCore.Services.Tests/ClassData/DashboardServiceClassData.cs
+++ b/AdminCore.Services.Tests/ClassData/DashboardServiceClassData.cs
@@ -1,0 +1,123 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using AdminCore.DAL.Models;
+using AdminCore.DTOs.Dashboard;
+using AdminCore.DTOs.Employee;
+using AutoFixture;
+
+namespace AdminCore.Services.Tests.ClassData
+{
+    public class DashboardServiceClassData
+    {
+        public class DashboardEventsClassData : IEnumerable<object[]>
+        {
+            public IEnumerator<object[]> GetEnumerator()
+            {
+                var fixture = new Fixture();
+                fixture.Behaviors.Remove(new ThrowingRecursionBehavior());
+                fixture.Behaviors.Add(new OmitOnRecursionBehavior());
+
+                var dateTimeToGet = new DateTime(2019, 07, 06 );
+
+                var employees = new EmployeeSnapshotDto
+                {
+                    EmployeeId = EmployeeId
+                };
+
+                var teams = new TeamSnapshotDto
+                {
+                    TeamId = 1,
+                    Employees = new List<EmployeeSnapshotDto>{ employees }
+                };
+
+                var projects = new ProjectSnapshotDto
+                {
+                    ProjectId = 1,
+                    Teams = new List<TeamSnapshotDto> { teams }
+                };
+
+                var clients = new ClientSnapshotDto
+                {
+                    ClientId = 1,
+                    Projects = new List<ProjectSnapshotDto> { projects }
+                };
+
+                // ARGS: employeeId: int, DateTime dateToGet, teamRepoOut IList<Team>, clientRepoOut IQueryable<Client>,
+                // clientSnapshotMapOut: ClientSnapshotDto, projectSnapshotMapOut: ProjectSnapshotDto, teamSnapshotMapOut: TeamSnapshotDto, employeeSnapshotMapOut: EmployeeSnapshotDto
+                yield return new object[]
+                {
+                    EmployeeId,
+                    dateTimeToGet,
+                    new List<Team>
+                    {
+                        new Team
+                        {
+                            TeamId = 1,
+                            ProjectId = 1
+                        }
+                    },
+                    new List<Client>
+                    {
+                        new Client
+                        {
+                            ClientId = 1,
+                            Projects = new List<Project>
+                            {
+                                new Project
+                                {
+                                    ProjectId = 1,
+                                    Teams = new List<Team>
+                                    {
+                                        new Team
+                                        {
+                                            TeamId = 1,
+                                            Contracts = new List<Contract>
+                                            {
+                                                new Contract
+                                                {
+                                                    ContractId = 1,
+                                                    TeamId = 1,
+                                                    EmployeeId = 1,
+                                                    Employee = new Employee
+                                                    {
+                                                        EmployeeId = 1,
+                                                        Events = new List<Event>
+                                                        {
+                                                            new Event
+                                                            {
+                                                                EventId = 1,
+                                                                EventDates = new List<EventDate>
+                                                                {
+                                                                    new EventDate
+                                                                    {
+                                                                        EventDateId = 1,
+                                                                        StartDate = dateTimeToGet,
+                                                                        EndDate = dateTimeToGet
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }.AsQueryable(),
+                    clients,
+                    projects,
+                    teams,
+                    employees
+                };
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+        }
+
+        private const int EmployeeId = 6;
+    }
+}

--- a/AdminCore.Services.Tests/DashboardServiceLogicTests.cs
+++ b/AdminCore.Services.Tests/DashboardServiceLogicTests.cs
@@ -129,27 +129,6 @@ namespace AdminCore.Services.Tests
       clientSnapShotActual.Should().BeEmpty();
     }
 
-    [Fact]
-    public void GetTeamDashboardEvents_ReposReturnNull_EmptySnapShotReturned()
-    {
-      // Arrange
-      GetMockedResourcesGetTeamDashboardEvents(null, null, null, null,
-        null, null, out var mapper, out var dashboardService, out var ormContext);
-
-      // Act
-      var clientSnapShotActual = dashboardService.GetTeamDashboardEvents(6, new DateTime(2019, 5, 6));
-
-      // Assert
-      ormContext.TeamRepository.Received(1).Get(Arg.Any<Expression<Func<Team, bool>>>(),
-        Arg.Any<Func<IQueryable<Team>, IOrderedQueryable<Team>>>(),
-        Arg.Any<Expression<Func<Team, object>>[]>());
-      ormContext.ClientRepository.Received(1).GetAsQueryable(Arg.Any<Expression<Func<Client, bool>>>(),
-        Arg.Any<Func<IQueryable<Client>, IOrderedQueryable<Client>>>(),
-        Arg.Any<Expression<Func<Client, object>>[]>());
-
-      clientSnapShotActual.Should().BeEmpty();
-    }
-
     private void GetMockedResourcesGetTeamDashboardEvents(IList<Team> teamRepoOut, IQueryable<Client> clientRepoOut,
       ClientSnapshotDto clientSnapshotMapOut, ProjectSnapshotDto projectSnapshotMapOut, TeamSnapshotDto teamSnapshotMapOut, EmployeeSnapshotDto employeeSnapshotMapOut,
       out IMapper mapper, out DashboardService dashboardService, out EntityFrameworkContext ormContext)

--- a/AdminCore.Services/DashboardService.cs
+++ b/AdminCore.Services/DashboardService.cs
@@ -12,7 +12,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using AdminCore.Constants;
-using AdminCore.DAL.Database;
 using Microsoft.EntityFrameworkCore;
 
 namespace AdminCore.Services
@@ -207,8 +206,15 @@ namespace AdminCore.Services
     private ClientSnapshotDto BuildClientSnapshot(Client client, DateTime date)
     {
       var clientSnapShot = _mapper.Map<ClientSnapshotDto>(client);
-      clientSnapShot.Teams = client.Projects.SelectMany(project => project.Teams).Select(clientTeam => BuildTeamSnapshot(clientTeam, date)).ToList();
+      clientSnapShot.Projects = client.Projects.Select(clientProject => BuildProjectSnapshot(clientProject, date)).ToList();
       return clientSnapShot;
+    }
+
+    private ProjectSnapshotDto BuildProjectSnapshot(Project project, DateTime date)
+    {
+      var projectSnapshot = _mapper.Map<ProjectSnapshotDto>(project);
+      projectSnapshot.Teams = project.Teams.Select(clientTeam => BuildTeamSnapshot(clientTeam, date)).ToList();
+      return projectSnapshot;
     }
 
     private TeamSnapshotDto BuildTeamSnapshot(Team team, DateTime date)

--- a/AdminCore.Services/DashboardService.cs
+++ b/AdminCore.Services/DashboardService.cs
@@ -83,14 +83,14 @@ namespace AdminCore.Services
       var teamsForEmployee = GetTeamIdsForEmployee(employeeId, date);
       var clientList = DatabaseContext.ClientRepository
         .GetAsQueryable(QueryClientsWithContractsForEmployeeId(teamsForEmployee, date))
-        ?.Include(client => client.Projects)
+        .Include(client => client.Projects)
         .ThenInclude(project => project.Teams)
         .ThenInclude(team => team.Contracts)
         .ThenInclude(contract => contract.Employee)
         .ThenInclude(employee => employee.Events)
         .ThenInclude(evnt => evnt.EventDates);
 
-      return clientList?.Select(client => BuildClientSnapshot(client, date)).ToList() ?? new List<ClientSnapshotDto>();
+      return clientList.Select(client => BuildClientSnapshot(client, date)).ToList();
     }
 
     public static bool EmployeeDashboardEventsQuery(int employeeId, DateTime date, Event evnt)
@@ -130,7 +130,7 @@ namespace AdminCore.Services
     private List<int> GetTeamIdsForEmployee(int employeeId, DateTime date)
     {
       return DatabaseContext.TeamRepository.Get(team => team.Contracts.Any(contract => contract.EmployeeId == employeeId && DateService.ContractIsActiveDuringDate(contract, date)))
-        ?.Select(team => team.TeamId).ToList() ?? new List<int>();
+        .Select(team => team.TeamId).ToList();
     }
 
     private static bool EmployeeDashboardEvents(Event evnt, int employeeId, int cancelled, DateTime startOfMonth, DateTime endOfMonth)
@@ -187,7 +187,7 @@ namespace AdminCore.Services
 
     private static EmployeeSnapshotDto CreateEmployeeSnapshotFromContract(Contract contract)
     {
-      return new EmployeeSnapshotDto()
+      return new EmployeeSnapshotDto
       {
         Email = contract.Employee.Email,
         EmployeeId = contract.EmployeeId,

--- a/AdminCore.Services/Mappings/DashboardMapperProfile.cs
+++ b/AdminCore.Services/Mappings/DashboardMapperProfile.cs
@@ -13,6 +13,7 @@ namespace AdminCore.Services.Mappings
     public DashboardMapperProfile()
     {
       CreateMap<Client, ClientSnapshotDto>().ReverseMap();
+      CreateMap<Project, ProjectSnapshotDto>().ReverseMap();
       CreateMap<Team, TeamSnapshotDto>().ReverseMap();
       CreateMap<Employee, EmployeeSnapshotDto>().ReverseMap();
     }

--- a/AdminCore.WebApi.Tests/Controllers/DashboardControllerTest.cs
+++ b/AdminCore.WebApi.Tests/Controllers/DashboardControllerTest.cs
@@ -103,7 +103,7 @@ namespace AdminCore.WebApi.Tests.Controllers
     }
 
     [Fact]
-    public void GetEmployeeTeamSnapshotReturnsOkResultWithClientSnapshotsWhenSnapshotsAreReturned()
+    public void GetEmployeeTeamSnapshot_ServiceReturnsSnapshotList_ReturnsOkResultWithClientSnapshots()
     {
       // Arrange
       var numberOfSnapshotModels = 6;
@@ -120,7 +120,7 @@ namespace AdminCore.WebApi.Tests.Controllers
     }
 
     [Fact]
-    public void GetEmployeeTeamSnapshotReturnsNoContentResultWhenNoSnapshotsAreReturned()
+    public void GetEmployeeTeamSnapshot_ServiceReturnsEmptySnapshot_ReturnsNoContentResult()
     {
       // Arrange
       _dashboardService.GetTeamDashboardEvents(TestEmployeeId, Arg.Any<DateTime>()).Returns(new List<ClientSnapshotDto>());
@@ -133,6 +133,19 @@ namespace AdminCore.WebApi.Tests.Controllers
       _dashboardService.Received(1).GetTeamDashboardEvents(TestEmployeeId, Arg.Any<DateTime>());
     }
 
+    [Fact]
+    public void GetEmployeeTeamSnapshot_ServiceReturnsNull_ReturnsNoContentResult()
+    {
+      // Arrange
+      _dashboardService.GetTeamDashboardEvents(TestEmployeeId, Arg.Any<DateTime>()).Returns(x => null);
+
+      // Act
+      var result = _dashboardController.GetEmployeeTeamSnapshot();
+
+      // Assert
+      AssertObjectResultIsNull<List<ClientSnapshotViewModel>>(result, HttpStatusCode.NoContent);
+      _dashboardService.Received(1).GetTeamDashboardEvents(TestEmployeeId, Arg.Any<DateTime>());
+    }
 
     [Fact]
     public void GetTeamEventsReturnsOkResultWithEventsWhenServiceReturnsEvents()

--- a/AdminCore.WebApp/Controllers/DashboardController.cs
+++ b/AdminCore.WebApp/Controllers/DashboardController.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using AdminCore.DTOs.Employee;
 using AdminCore.WebApi.Models.Dashboard;
 using AdminCore.WebApi.Models.Event;
+using Microsoft.AspNetCore.Http;
 
 namespace AdminCore.WebApi.Controllers
 {
@@ -26,6 +27,8 @@ namespace AdminCore.WebApi.Controllers
     }
 
     [HttpGet("getDashboardSnapshot")]
+    [ProducesResponseType(typeof(IList<DashboardEventViewModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public IActionResult GetDashboardSnapshot()
     {
       var dashboardSnapshot = _dashboardService.GetEmployeeDashboardEvents(_employee.EmployeeId, DateTime.Today);
@@ -38,6 +41,7 @@ namespace AdminCore.WebApi.Controllers
     }
 
     [HttpGet("getEmployeeEvents/{date}")]
+    [ProducesResponseType(typeof(IList<EventViewModel>), StatusCodes.Status200OK)]
     public IActionResult GetEmployeeEvents(DateTime date)
     {
       var employeeEvents = _dashboardService.GetEmployeeEventsForMonth(_employee.EmployeeId, date);
@@ -45,6 +49,8 @@ namespace AdminCore.WebApi.Controllers
     }
 
     [HttpGet("getEmployeeTeamSnapshot")]
+    [ProducesResponseType(typeof(IList<ClientSnapshotViewModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public IActionResult GetEmployeeTeamSnapshot()
     {
       var employeeTeamSnapshot = _dashboardService.GetTeamDashboardEvents(_employee.EmployeeId, DateTime.Today);
@@ -57,6 +63,8 @@ namespace AdminCore.WebApi.Controllers
     }
 
     [HttpGet("getTeamEvents/{date}")]
+    [ProducesResponseType(typeof(IList<EventViewModel>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
     public IActionResult GetTeamEvents(DateTime date)
     {
       var teamEvents = _dashboardService.GetEmployeeTeamEvents(_employee.EmployeeId, date);

--- a/AdminCore.WebApp/Controllers/DashboardController.cs
+++ b/AdminCore.WebApp/Controllers/DashboardController.cs
@@ -8,7 +8,6 @@ using System.Linq;
 using AdminCore.DTOs.Employee;
 using AdminCore.WebApi.Models.Dashboard;
 using AdminCore.WebApi.Models.Event;
-using AdminCore.WebApi.Models.EventMessage;
 
 namespace AdminCore.WebApi.Controllers
 {

--- a/AdminCore.WebApp/Controllers/DashboardController.cs
+++ b/AdminCore.WebApp/Controllers/DashboardController.cs
@@ -48,12 +48,12 @@ namespace AdminCore.WebApi.Controllers
     public IActionResult GetEmployeeTeamSnapshot()
     {
       var employeeTeamSnapshot = _dashboardService.GetTeamDashboardEvents(_employee.EmployeeId, DateTime.Today);
-      if (employeeTeamSnapshot.Any())
+      if (employeeTeamSnapshot == null || !employeeTeamSnapshot.Any())
       {
-        return Ok(Mapper.Map<IList<ClientSnapshotViewModel>>(employeeTeamSnapshot));
+        return NoContent();
       }
 
-      return NoContent();
+      return Ok(Mapper.Map<IList<ClientSnapshotViewModel>>(employeeTeamSnapshot));
     }
 
     [HttpGet("getTeamEvents/{date}")]

--- a/AdminCore.WebApp/Mappings/WebMappingProfile.cs
+++ b/AdminCore.WebApp/Mappings/WebMappingProfile.cs
@@ -72,6 +72,7 @@ namespace AdminCore.WebApi.Mappings
       CreateMap<ContractDto, UpdateContractViewModel>().ReverseMap();
 
       CreateMap<ClientSnapshotDto, ClientSnapshotViewModel>().ReverseMap();
+      CreateMap<ProjectSnapshotDto, ProjectSnapshotViewModel>().ReverseMap();
       CreateMap<TeamSnapshotDto, TeamSnapshotViewModel>().ReverseMap();
       CreateMap<EmployeeSnapshotDto, EmployeeSnapshotViewModel>().ReverseMap();
     }

--- a/AdminCore.WebApp/Models/Dashboard/ClientSnapshotViewModel.cs
+++ b/AdminCore.WebApp/Models/Dashboard/ClientSnapshotViewModel.cs
@@ -7,8 +7,8 @@ namespace AdminCore.WebApi.Models.Dashboard
   {
     public int ClientId { get; set; }
 
-    public string ClientName { get; set; } 
+    public string ClientName { get; set; }
 
-    public ICollection<TeamSnapshotViewModel> Teams { get; set; }
+    public ICollection<ProjectSnapshotViewModel> Projects { get; set; }
   }
 }

--- a/AdminCore.WebApp/Models/Dashboard/ProjectSnapshotViewModel.cs
+++ b/AdminCore.WebApp/Models/Dashboard/ProjectSnapshotViewModel.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using AdminCore.WebApi.Models.Base;
+
+namespace AdminCore.WebApi.Models.Dashboard
+{
+  public class ProjectSnapshotViewModel : ViewModel
+  {
+    public int ProjectId { get; set; }
+
+    public string ProjectName { get; set; }
+
+    public ICollection<TeamSnapshotViewModel> Teams { get; set; }
+  }
+}


### PR DESCRIPTION
Changes to the dashboard controller, service, dtos and viewmodels.

Additional null handling in existing methods has been added and requisite tests are included.

These changes modify the ClientSnapshotViewmodel which will break the current implementation of the frontend.